### PR TITLE
[hydrus_xi][model] calculation of external force compensation

### DIFF
--- a/robots/hydrus/include/hydrus/hydrus_tilted_robot_model.h
+++ b/robots/hydrus/include/hydrus/hydrus_tilted_robot_model.h
@@ -47,6 +47,19 @@ public:
 
   virtual void calcStaticThrust() override;
 
+  void setTargetForceInRootEnd(Eigen::Vector3d target_force) {target_force_in_root_end_ = target_force;}
+  void setTargetForceInLinkEnd(Eigen::Vector3d target_force) {target_force_in_link_end_ = target_force;}
+  Eigen::Vector3d getCompensateTorqueForRootEndInCog() {return compensate_torque_for_root_end_in_cog_;}
+  Eigen::Vector3d getCompensateTorqueForLinkEndInCog() {return compensate_torque_for_link_end_in_cog_;}
+
 private:
   void updateRobotModelImpl(const KDL::JntArray& joint_positions) override;
+
+  std::string root_end_name_;
+  std::string link_end_name_;
+  Eigen::Vector3d target_force_in_root_end_;
+  Eigen::Vector3d target_force_in_link_end_;
+  Eigen::Vector3d compensate_torque_for_root_end_in_cog_;
+  Eigen::Vector3d compensate_torque_for_link_end_in_cog_;
+
 };

--- a/robots/hydrus_xi/robots/quad/default.urdf.xacro
+++ b/robots/hydrus_xi/robots/quad/default.urdf.xacro
@@ -23,4 +23,38 @@
           izz="0.00002"/>
     </inertial>
   </xacro:extra_module>
+
+  #### virtual links for end effectors ####
+  <link name="link1_end">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.00001"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000001"/>
+    </inertial>
+  </link>
+  <joint name="link1_end_joint" type="fixed">
+    <parent link="link1"/>
+    <child link="link1_end"/>
+    <origin xyz="0 0 0" rpy="0 0 ${pi}"/>
+  </joint>
+
+  <link name="link4_end">
+    <inertial>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <mass value="0.00001"/>
+      <inertia
+          ixx="0.000001" ixy="0.0" ixz="0.0"
+          iyy="0.000001" iyz="0.0"
+          izz="0.000001"/>
+    </inertial>
+  </link>
+  <joint name="link4_end_joint" type="fixed">
+    <parent link="link4"/>
+    <child link="link4_end"/>
+    <origin xyz="${link_length} 0 0" rpy="0 0 0"/>
+  </joint>
+
 </robot>


### PR DESCRIPTION
@koutarou-kaneko Please review this PR.

### What is this
calclate torque in cog frame to compensate force on the end-effectors.

### Details
- added virtual links to four links type of hydrus_xi. They are named `link1_end` and `link4_end` as shown in the figure.
- calculate torque in cog frame to compensate force on these end-effectors.

### TODO
- you should add some ros topics to set target force in end-effector and to get compensation torque.

### Caution
torque is expressed to generate force on the end-effector.
So, when the target force on `link1_end` in the following figure is `[1.0, 0.0, 0.0]` for example, the calculated yaw torque will be negative value.


### Figure
![Screenshot 2023-11-23 23:28:19](https://github.com/koutarou-kaneko/jsk_aerial_robot/assets/64698144/cf3c2423-6150-4e35-b56b-84731da04c91)

